### PR TITLE
Get EcoBase working with Julia v0.6-1.0 and fix some bugs

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.7
+julia 0.6
+Compat 0.59.0
 
 RecipesBase

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -1,3 +1,4 @@
+using Compat
 
 # Functions - most have to be implemented with the concrete type
 occurrences(asm::AbstractAssemblage) = error("function not defined for this type")
@@ -28,11 +29,11 @@ noccupied(x, idx) = length(occupied(x, idx))
 thingoccurrences(asm::AbstractAssemblage, idx) = view(occurrences(asm), idx, :)
 placeoccurrences(asm::AbstractAssemblage, idx) = view(occurrences(asm), :, idx) # make certain that the view implementation also takes thing or place names
 
-richness(asm::AbstractAssemblage{Bool, T, P}) where {T, P} = vec(sum(occurrences(asm), 1))
-richness(asm::AbstractAssemblage) = vec(mapslices(nnz, occurrences(asm), 1))
+richness(asm::AbstractAssemblage{Bool, T, P}) where {T, P} = vec(Compat.sum(occurrences(asm), dims=1))
+richness(asm::AbstractAssemblage) = vec(mapslices(nnz, occurrences(asm), dims=1))
 
-occupancy(asm::AbstractAssemblage{Bool, T, P}) where {T, P} = vec(sum(occurrences(asm), 2))
-occupancy(asm::AbstractAssemblage) = vec(mapslices(nnz, occurrences(asm), 2))
+occupancy(asm::AbstractAssemblage{Bool, T, P}) where {T, P} = vec(Compat.sum(occurrences(asm), dims=2))
+occupancy(asm::AbstractAssemblage) = vec(mapslices(nnz, occurrences(asm), dims=2))
 
 records(asm::AbstractAssemblage) = nnz(occurrences(asm))
 

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -12,15 +12,19 @@ placenames(plc::AbstractPlaces) = error("function not defined for this type")
 nthings(thg::AbstractThings) = error("function not defined for this type")
 thingnames(thg::AbstractThings) = error("function not defined for this type")
 
-nzrows(a::AbstractMatrix) = find(sum(a .> 0, 2) .> 0)
-nzcols(a::AbstractMatrix) = find(sum(a .> 0, 1) .> 0)
-nnz(a::AbstractArray) = sum(a .> 0)
+nzrows(a::AbstractMatrix) = LinearIndices(Compat.sum(a .> 0, dims=2))[findall(Compat.sum(a .> 0, dims=2) .> 0)]
+nzcols(a::AbstractMatrix) = LinearIndices(Compat.sum(a .> 0, dims=1))[findall(Compat.sum(a .> 0, dims=1) .> 0)]
+nnz(a::AbstractArray) = Compat.sum(a .> 0)
 
 occurring(asm::AbstractAssemblage) = nzrows(occurrences(asm))
 occupied(asm::AbstractAssemblage) = nzcols(occurrences(asm))
-occupied(asm::AbstractAssemblage, idx) = findn(occurrences(asm)[idx, :])
-occurring(asm::AbstractAssemblage, idx) = findn(occurrences(asm)[:, idx])
-
+if VERSION < v"0.7.0-"
+    occupied(asm::AbstractAssemblage, idx) = collect(zip(findn(occurrences(asm)[idx, :])))
+    occurring(asm::AbstractAssemblage, idx) = collect(zip(findn(occurrences(asm)[:, idx])))
+else
+    occupied(asm::AbstractAssemblage, idx) = findall(!iszero, occurrences(asm)[idx, :])
+    occurring(asm::AbstractAssemblage, idx) = findall(!iszero, occurrences(asm)[:, idx])
+end
 noccurring(x) = length(occurring(x))
 noccupied(x) = length(occupied(x))
 noccurring(x, idx) = length(occurring(x, idx))

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+Diversity 0.5.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,64 @@
-using EcoBase
-using Base.Test
+using Compat
+using Compat.Test
+using Compat: @info
 
-# write your own tests here
-@test 1 == 2
+# Identify files in test/ that are testing matching files in src/
+#  - src/Source.jl will be matched by test/test_Source.jl
+
+filebase = map(file -> replace(file, r"(.*).jl$" => s"\1"),
+                filter(file -> occursin(r".*\.jl$", file),
+                       readdir("../src")))
+testbase = map(file -> replace(file, r"test_(.*).jl$" => s"\1"),
+                filter(str -> occursin(r"^test_.*\.jl$", str), readdir()))
+
+println()
+@info "Running tests for files:"
+for t in testbase
+    println("    = $t.jl")
+end
+println()
+
+@testset "* Testing $t.jl" for t in testbase
+    include("test_$t.jl")
+end
+
+# Identify tests with no matching file
+superfluous = filter(f -> f ∉ filebase, testbase)
+if length(superfluous) > 0
+    println()
+    @info "Potentially superfluous tests:"
+    for f in superfluous
+        println("    + $f.jl")
+    end
+    println()
+end
+
+# Identify files with no matching test
+missing = filter(f -> f ∉ testbase, filebase)
+if length(missing) > 0
+    println()
+    @info "Potentially missing tests:"
+    for f in missing
+        println("    - $f.jl")
+    end
+    println()
+end
+
+# Identify files that are cross-validating results against other packages
+# test/pkg_Package.jl should validate results against the Package package
+
+pkgbase = map(file -> replace(file, r"pkg_(.*).jl$" => s"\1"),
+                   filter(str -> occursin(r"^pkg_.*\.jl$", str),
+                          readdir()))
+
+if length(pkgbase) > 0
+    @info "Running cross-validation against:"
+    for p in pkgbase
+        println("    = $p")
+    end
+    println()
+
+    @testset " * Validating against $p" for p in pkgbase
+        include("pkg_$p.jl")
+    end
+end

--- a/test/test_Interface.jl
+++ b/test/test_Interface.jl
@@ -1,0 +1,38 @@
+module TestInterface
+using Compat.Test
+
+# Checking interface through Diversity.jl
+using Diversity
+using EcoBase
+
+numspecies = 10;
+numcommunities = 8;
+manyweights = rand(numspecies, numcommunities);
+manyweights /= sum(manyweights);
+
+@testset "EcoBase interface" begin
+    species = map(n -> "Species $n", 1:numspecies)
+    communities = map(n -> "SC $n", 1:numcommunities)
+    ut = UniqueTypes(species)
+    sc = Subcommunities(communities)
+    mc = Metacommunity(manyweights, ut, sc)
+
+    @test all(thingnames(mc) .== species)
+    @test all(placenames(mc) .== communities)
+    @test all(occurrences(mc) .≈ manyweights)
+    @test all(richness(mc) .== repeat([numspecies], inner=numcommunities))
+    @test all(occupancy(mc) .== repeat([numcommunities], inner=numspecies))
+    fewerweights = deepcopy(manyweights)
+    fewerweights[1, 1] = 0
+    fewerweights /= sum(fewerweights)
+    fmc = Metacommunity(fewerweights, ut, sc)
+
+    @test noccupied(fmc) == numcommunities
+    @test noccurring(fmc) == numspecies
+    @test noccupied(fmc, 1) == numcommunities - 1
+    @test noccurring(fmc, 1) == numspecies - 1
+    @test nthings(fmc) == numspecies
+    @test nplaces(fmc) == numcommunities
+end
+
+end


### PR DESCRIPTION
Now the `@forward_func` macro isn't in `EcoBase`, there's no reason for it not to work in earlier Julia versions. This patch includes all of the fixes in [Diversity.EcoBase](https://github.com/richardreeve/Diversity.jl/tree/master/ext/EcoBase) from `Diversity` v0.4.4. There is one terrible hack to fix an incompatibility with 1.0 which it would be great to do better, but I'm not sure how it's used in `SpatialEcology`, and the tests fail because they rely on `Diversity` using `EcoJulia/EcoBase`, which won't happen until at least the v0.5 release.