### PR TITLE
Updates to EcoBase

### DIFF
--- a/src/DataTypes.jl
+++ b/src/DataTypes.jl
@@ -42,7 +42,7 @@ abstract type AbstractLocations <: AbstractPlaces end
 Subtype of AbstractLocations that refers to a grid of regularly
 spaced, identically shaped, locations.
 """
-abstract type AbstractGrid <: AbstractLocations end
+abstract type AbstractGrid end
 
 """
     AbstractAssemblage{D <: Real (e.g. Int, Float64, Bool),

--- a/src/EcoBase.jl
+++ b/src/EcoBase.jl
@@ -4,12 +4,11 @@ import Base: show
 import RecipesBase
 
 include("DataTypes.jl")
-
 include("Interface.jl")
-export nthings, nplaces, occupancy, richness, records, placenames, thingnames
-export occurring, noccurring, occupied, noccupied, occurrences
-export indices, coordinates, xcells, ycells, cells, xmin, xmax, ymin, ymax
-export xrange, yrange, xcellsize, ycellsize, cellsize
+#export nthings, nplaces, occupancy, richness, records, placenames, thingnames
+#export occurring, noccurring, occupied, noccupied, occurrences
+#export indices, coordinates, xcells, ycells, cells, xmin, xmax, ymin, ymax
+#export xrange, yrange, xcellsize, ycellsize, cellsize
 
 include("PlotRecipes.jl")
 end # module

--- a/src/EcoBase.jl
+++ b/src/EcoBase.jl
@@ -5,10 +5,12 @@ import RecipesBase
 
 include("DataTypes.jl")
 include("Interface.jl")
-#export nthings, nplaces, occupancy, richness, records, placenames, thingnames
-#export occurring, noccurring, occupied, noccupied, occurrences
-#export indices, coordinates, xcells, ycells, cells, xmin, xmax, ymin, ymax
-#export xrange, yrange, xcellsize, ycellsize, cellsize
-
 include("PlotRecipes.jl")
+
+export nthings, nplaces, occupancy, richness, records, placenames, thingnames
+export occurring, noccurring, occupied, noccupied, occurrences
+export placeoccurrences, thingoccurrences, cooccurring, places, things
+export indices, coordinates, xcells, ycells, cells, xmin, xmax, ymin, ymax
+export xrange, yrange, xcellsize, ycellsize, cellsize, getcoords
+
 end # module

--- a/src/EcoBase.jl
+++ b/src/EcoBase.jl
@@ -1,6 +1,6 @@
 module EcoBase
 
-import Base: show
+import Base: show, view
 import RecipesBase
 
 include("DataTypes.jl")

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -16,15 +16,22 @@ nzrows(a::AbstractMatrix) = findall(vec(Compat.sum(a, dims = 2) .> 0))
 nzcols(a::AbstractMatrix) = findall(vec(Compat.sum(a, dims = 1) .> 0))
 nnz(a::AbstractArray) = Compat.sum(a .> 0)
 
-occurring(asm::AbstractAssemblage) = nzrows(occurrences(asm))
-occupied(asm::AbstractAssemblage) = nzcols(occurrences(asm))
+occurring(asm::AbstractAssemblage) = occurring(occurrences(asm))
+occurring(a::AbstractMatrix) = nzrows(a)
+occurring(asm::AbstractAssemblage, idx) = occurring(occurrences(asm), idx)
+
+occupied(asm::AbstractAssemblage) = occupied(occurrences(asm))
+occupied(asm::AbstractAssemblage, idx) = occupied(occurrences(asm), idx)
+occupied(a::AbstractMatrix) = nzcols(a)
+
 if VERSION < v"0.7.0-"
-    occupied(asm::AbstractAssemblage, idx) = collect(zip(findn(occurrences(asm)[idx, :])))
-    occurring(asm::AbstractAssemblage, idx) = collect(zip(findn(occurrences(asm)[:, idx])))
+    occupied(a::AbstractMatrix, idx) = collect(zip(findn(a[idx, :])))
+    occurring(a::AbstractMatrix, idx) = collect(zip(findn(a[:, idx])))
 else
-    occupied(asm::AbstractAssemblage, idx) = findall(!iszero, occurrences(asm)[idx, :])
-    occurring(asm::AbstractAssemblage, idx) = findall(!iszero, occurrences(asm)[:, idx])
+    occupied(a::AbstractMatrix, idx) = findall(!iszero, a[idx, :])
+    occurring(a::AbstractMatrix, idx) = findall(!iszero, a[:, idx])
 end
+
 noccurring(x) = length(occurring(x))
 noccupied(x) = length(occupied(x))
 noccurring(x, idx) = length(occurring(x, idx))
@@ -35,13 +42,16 @@ thingoccurrences(mat::AbstractMatrix, idx) = view(mat, idx, :)
 placeoccurrences(asm::AbstractAssemblage, idx) = placeoccurrences(occurrences(asm), idx)
 placeoccurrences(mat::AbstractMatrix, idx) = view(occurrences(asm), :, idx) # make certain that the view implementation also takes thing or place names
 
-richness(asm::AbstractAssemblage{Bool, T, P}) where {T, P} = vec(Compat.sum(occurrences(asm), dims=1))
-richness(asm::AbstractAssemblage) = vec(mapslices(nnz, occurrences(asm), dims=1))
+richness(asm::AbstractAssemblage) = richness(occurrences(asm))
+richness(a::AbstractMatrix{Bool}) = vec(Compat.sum(a, dims = 1))
+richness(a::AbstractMatrix) = vec(mapslices(nnz, a, dims = 1))
 
-occupancy(asm::AbstractAssemblage{Bool, T, P}) where {T, P} = vec(Compat.sum(occurrences(asm), dims=2))
-occupancy(asm::AbstractAssemblage) = vec(mapslices(nnz, occurrences(asm), dims=2))
+occupancy(asm::AbstractAssemblage) = occupancy(occurrences(asm))
+occupancy(a::AbstractMatrix{Bool}) = vec(Compat.sum(a, dims=2))
+occupancy(a::AbstractMatrix) = vec(mapslices(nnz, a, dims=2))
 
-nrecords(asm::AbstractAssemblage) = nnz(occurrences(asm))
+nrecords(asm::AbstractAssemblage) = nrecords(occurrences(asm))
+nrecords(a::AbstractMatrix) = nnz(a)
 
 cooccurring(asm::AbstractAssemblage, inds...) = cooccurring(asm, [inds...])
 function cooccurring(asm::AbstractAssemblage, inds::AbstractVector)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -1,16 +1,16 @@
 using Compat
 
 # Functions - most have to be implemented with the concrete type
-occurrences(asm::AbstractAssemblage)::AbstractMatrix = error("function not defined for this type")
-view(asm::AbstractAssemblage) = error("function not defined for this type")
-places(asm::AbstractAssemblage)::AbstratPlaces = error("function not defined for this type")
-things(asm::AbstractAssemblage)::AbstractThings = error("function not defined for this type")
+occurrences(asm::AbstractAssemblage)::AbstractMatrix = error("function not defined for $(typeof(asm))")
+view(asm::AbstractAssemblage) = error("function not defined for $(typeof(asm))")
+places(asm::AbstractAssemblage)::AbstratPlaces = error("function not defined for $(typeof(asm))")
+things(asm::AbstractAssemblage)::AbstractThings = error("function not defined for $(typeof(asm))")
 
-nplaces(plc::AbstractPlaces)::Integer = error("function not defined for this type")
-placenames(plc::AbstractPlaces)::AbstractVector{<:String} = error("function not defined for this type")
+nplaces(plc::AbstractPlaces)::Integer = error("function not defined for $(typeof(plc))")
+placenames(plc::AbstractPlaces)::AbstractVector{<:String} = error("function not defined for $(typeof(plc))")
 
-nthings(thg::AbstractThings)::Integer = error("function not defined for this type")
-thingnames(thg::AbstractThings)::AbstractVector{<:String} = error("function not defined for this type")
+nthings(thg::AbstractThings)::Integer = error("function not defined for $(typeof(thg))")
+thingnames(thg::AbstractThings)::AbstractVector{<:String} = error("function not defined for $(typeof(thg))")
 
 nzrows(a::AbstractMatrix) = findall(vec(Compat.sum(a, dims = 2) .> 0))
 nzcols(a::AbstractMatrix) = findall(vec(Compat.sum(a, dims = 1) .> 0))
@@ -53,8 +53,8 @@ occupancy(a::AbstractMatrix) = vec(mapslices(nnz, a, dims=2))
 nrecords(asm::AbstractAssemblage) = nrecords(occurrences(asm))
 nrecords(a::AbstractMatrix) = nnz(a)
 
-cooccurring(asm::AbstractAssemblage, inds...) = cooccurring(asm, [inds...])
-function cooccurring(asm::AbstractAssemblage, inds::AbstractVector)
+cooccurring(asm, inds...) = cooccurring(asm, [inds...])
+function cooccurring(asm, inds::AbstractVector)
     sub = view(asm, species = inds)
     richness(sub) .== nthings(sub)
 end
@@ -86,22 +86,24 @@ placenames(asm::AbstractAssemblage, args...) = placenames(places(asm), args...)
 nthings(asm::AbstractAssemblage, args...) = nthings(things(asm), args...)
 thingnames(asm::AbstractAssemblage, args...) = thingnames(things(asm), args...)
 
+
 # TODO:
 # accessing cache
 
-xmin(grd::AbstractGrid) = error("function not defined for this type")
-ymin(grd::AbstractGrid) = error("function not defined for this type")
-xcellsize(grd::AbstractGrid) = error("function not defined for this type")
-ycellsize(grd::AbstractGrid) = error("function not defined for this type")
-xcells(grd::AbstractGrid) = error("function not defined for this type")
-ycells(grd::AbstractGrid) = error("function not defined for this type")
-cellsize(grd::AbstractGrid) = xcellsize(grd), ycellsize(grd)
-cells(grd::AbstractGrid) = xcells(grd), ycells(grd)
-xrange(grd::AbstractGrid) = xmin(grd):xcellsize(grd):xmax(grd) #includes intermediary points
-yrange(grd::AbstractGrid) = ymin(grd):ycellsize(grd):ymax(grd)
-xmax(grd::AbstractGrid) = xmin(grd) + xcellsize(grd) * (xcells(grd) - 1)
-ymax(grd::AbstractGrid) = ymin(grd) + ycellsize(grd) * (ycells(grd) - 1)
+# Methods for AbstractGrid
+xmin(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
+ymin(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
+xcellsize(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
+ycellsize(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
+xcells(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
+ycells(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
+cellsize(grd) = xcellsize(grd), ycellsize(grd)
+cells(grd) = xcells(grd), ycells(grd)
+xrange(grd) = xmin(grd):xcellsize(grd):xmax(grd) #includes intermediary points
+yrange(grd) = ymin(grd):ycellsize(grd):ymax(grd)
+xmax(grd) = xmin(grd) + xcellsize(grd) * (xcells(grd) - 1)
+ymax(grd) = ymin(grd) + ycellsize(grd) * (ycells(grd) - 1)
 
 
-indices(grd::AbstractGrid, idx) = error("function not defined for this type") #Implement this in SpatialEcology!
-coordinates(grd::AbstractGrid) = error("function not defined for this type")
+indices(grd::AbstractGrid, idx) = error("function not defined for $(typeof(grd))") #Implement this in SpatialEcology!
+coordinates(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -12,8 +12,8 @@ placenames(plc::AbstractPlaces) = error("function not defined for this type")
 nthings(thg::AbstractThings) = error("function not defined for this type")
 thingnames(thg::AbstractThings) = error("function not defined for this type")
 
-nzrows(a::AbstractMatrix) = LinearIndices(Compat.sum(a .> 0, dims=2))[findall(Compat.sum(a .> 0, dims=2) .> 0)]
-nzcols(a::AbstractMatrix) = LinearIndices(Compat.sum(a .> 0, dims=1))[findall(Compat.sum(a .> 0, dims=1) .> 0)]
+nzrows(a::AbstractMatrix) = findall(vec(Compat.sum(a, dims = 2) .> 0))
+nzcols(a::AbstractMatrix) = findall(vec(Compat.sum(a, dims = 1) .> 0))
 nnz(a::AbstractArray) = Compat.sum(a .> 0)
 
 occurring(asm::AbstractAssemblage) = nzrows(occurrences(asm))

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -1,16 +1,16 @@
 using Compat
 
 # Functions - most have to be implemented with the concrete type
-occurrences(asm::AbstractAssemblage) = error("function not defined for this type")
+occurrences(asm::AbstractAssemblage)::AbstractMatrix = error("function not defined for this type")
 view(asm::AbstractAssemblage) = error("function not defined for this type")
-places(asm::AbstractAssemblage) = error("function not defined for this type")
-things(asm::AbstractAssemblage) = error("function not defined for this type")
+places(asm::AbstractAssemblage)::AbstratPlaces = error("function not defined for this type")
+things(asm::AbstractAssemblage)::AbstractThings = error("function not defined for this type")
 
-nplaces(plc::AbstractPlaces) = error("function not defined for this type")
-placenames(plc::AbstractPlaces) = error("function not defined for this type")
+nplaces(plc::AbstractPlaces)::Integer = error("function not defined for this type")
+placenames(plc::AbstractPlaces)::AbstractVector{<:String} = error("function not defined for this type")
 
-nthings(thg::AbstractThings) = error("function not defined for this type")
-thingnames(thg::AbstractThings) = error("function not defined for this type")
+nthings(thg::AbstractThings)::Integer = error("function not defined for this type")
+thingnames(thg::AbstractThings)::AbstractVector{<:String} = error("function not defined for this type")
 
 nzrows(a::AbstractMatrix) = findall(vec(Compat.sum(a, dims = 2) .> 0))
 nzcols(a::AbstractMatrix) = findall(vec(Compat.sum(a, dims = 1) .> 0))

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -39,7 +39,7 @@ richness(asm::AbstractAssemblage) = vec(mapslices(nnz, occurrences(asm), dims=1)
 occupancy(asm::AbstractAssemblage{Bool, T, P}) where {T, P} = vec(Compat.sum(occurrences(asm), dims=2))
 occupancy(asm::AbstractAssemblage) = vec(mapslices(nnz, occurrences(asm), dims=2))
 
-records(asm::AbstractAssemblage) = nnz(occurrences(asm))
+nrecords(asm::AbstractAssemblage) = nnz(occurrences(asm))
 
 cooccurring(asm::AbstractAssemblage, inds...) = cooccurring(asm, [inds...])
 function cooccurring(asm::AbstractAssemblage, inds::AbstractVector)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -30,8 +30,10 @@ noccupied(x) = length(occupied(x))
 noccurring(x, idx) = length(occurring(x, idx))
 noccupied(x, idx) = length(occupied(x, idx))
 
-thingoccurrences(asm::AbstractAssemblage, idx) = view(occurrences(asm), idx, :)
-placeoccurrences(asm::AbstractAssemblage, idx) = view(occurrences(asm), :, idx) # make certain that the view implementation also takes thing or place names
+thingoccurrences(asm::AbstractAssemblage, idx) = thingoccurrences(occurrences(asm), idx)
+thingoccurrences(mat::AbstractMatrix, idx) = view(mat, idx, :)
+placeoccurrences(asm::AbstractAssemblage, idx) = placeoccurrences(occurrences(asm), idx)
+placeoccurrences(mat::AbstractMatrix, idx) = view(occurrences(asm), :, idx) # make certain that the view implementation also takes thing or place names
 
 richness(asm::AbstractAssemblage{Bool, T, P}) where {T, P} = vec(Compat.sum(occurrences(asm), dims=1))
 richness(asm::AbstractAssemblage) = vec(mapslices(nnz, occurrences(asm), dims=1))

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -7,10 +7,15 @@ places(asm::AbstractAssemblage)::AbstractPlaces = error("function not defined fo
 things(asm::AbstractAssemblage)::AbstractThings = error("function not defined for $(typeof(asm))")
 
 nplaces(plc::AbstractPlaces)::Integer = error("function not defined for $(typeof(plc))")
+nplaces(plc::AbstractAssemblage) = nplaces(places(plc))
 placenames(plc::AbstractPlaces)::AbstractVector{<:String} = error("function not defined for $(typeof(plc))")
+placenames(plc::AbstractAssemblage) = placenames(places(plc))
+getcoords(plc::AbstractPlaces) = error("function not defined for $(typeof(plc))") # to get either Grid or other location data out of a Places object
 
 nthings(thg::AbstractThings)::Integer = error("function not defined for $(typeof(thg))")
+nthings(asm::AbstractAssemblage) = nthings(things(asm))
 thingnames(thg::AbstractThings)::AbstractVector{<:String} = error("function not defined for $(typeof(thg))")
+thingnames(asm::AbstractAssemblage) = thingnames(things(asm))
 
 nzrows(a::AbstractMatrix) = findall(vec(Compat.sum(a, dims = 2) .> 0))
 nzcols(a::AbstractMatrix) = findall(vec(Compat.sum(a, dims = 1) .> 0))
@@ -104,6 +109,6 @@ yrange(grd) = ymin(grd):ycellsize(grd):ymax(grd)
 xmax(grd) = xmin(grd) + xcellsize(grd) * (xcells(grd) - 1)
 ymax(grd) = ymin(grd) + ycellsize(grd) * (ycells(grd) - 1)
 
-
-indices(grd::AbstractGrid, idx) = error("function not defined for $(typeof(grd))") #Implement this in SpatialEcology!
+indices(grd::AbstractGrid) = error("function not defined for $(typeof(grd))") 
+indices(grd::AbstractGrid, idx) = error("function not defined for $(typeof(grd))")
 coordinates(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -3,7 +3,7 @@ using Compat
 # Functions - most have to be implemented with the concrete type
 occurrences(asm::AbstractAssemblage)::AbstractMatrix = error("function not defined for $(typeof(asm))")
 view(asm::AbstractAssemblage) = error("function not defined for $(typeof(asm))")
-places(asm::AbstractAssemblage)::AbstratPlaces = error("function not defined for $(typeof(asm))")
+places(asm::AbstractAssemblage)::AbstractPlaces = error("function not defined for $(typeof(asm))")
 things(asm::AbstractAssemblage)::AbstractThings = error("function not defined for $(typeof(asm))")
 
 nplaces(plc::AbstractPlaces)::Integer = error("function not defined for $(typeof(plc))")

--- a/src/PlotRecipes.jl
+++ b/src/PlotRecipes.jl
@@ -9,7 +9,6 @@ function convert_to_image(var::AbstractVector, grd::AbstractGrid)
 end
 
 RecipesBase.@recipe function f(var::AbstractVector, grd::AbstractGrid)
-    registercolors()
     seriestype := :heatmap
     aspect_ratio --> :equal
     grid --> false
@@ -21,7 +20,6 @@ end
 # end
 
 RecipesBase.@recipe function f(var::AbstractVector, pnt::AbstractLocations)
-    registercolors()
     seriestype := :scatter
     aspect_ratio --> :equal
     grid --> false

--- a/src/PlotRecipes.jl
+++ b/src/PlotRecipes.jl
@@ -1,7 +1,7 @@
 
 
 function convert_to_image(var::AbstractVector, grd::AbstractGrid)
-    x = Matrix{Float64}(reverse(cells(grd))...)
+    x = Matrix{Float64}(undef, reverse(cells(grd))...)
     fill!(x, NaN)
     xind, yind =  indices(grd, 1), indices(grd,2) #since matrices are drawn from upper left corner
     [x[yind[i], xind[i]] = val for (i, val) in enumerate(var)]
@@ -35,18 +35,13 @@ RecipesBase.@recipe function f(asm::AbstractAssemblage; occupied = true)
         var = [Float64(v) for v in var]
         (var[var.==0] .= NaN)
     end
-    var, asm.site
+    var, getcoords(places(asm))
 end
-
 
 RecipesBase.@recipe function f(var::AbstractVector, asm::AbstractAssemblage)
-    var, asm.site
-end
-
-RecipesBase.@recipe function f(var::Symbol, asm::AbstractAssemblage)
-    asm.site.sitestats[var], asm.site
+    var, getcoords(places(asm))
 end
 
 RecipesBase.@recipe function f(g::Function, asm::AbstractAssemblage)
-    g(asm), asm.site
+    g(asm), getcoords(places(asm))
 end

--- a/test/test_Interface.jl
+++ b/test/test_Interface.jl
@@ -3,14 +3,45 @@ using Compat.Test
 
 # Checking interface through Diversity.jl
 using Diversity
+using SpatialEcology
 using EcoBase
 
-numspecies = 10;
-numcommunities = 8;
-manyweights = rand(numspecies, numcommunities);
-manyweights /= sum(manyweights);
+@testset "SpatialEcology-Diversity interface" begin
+    numspecies = 10
+    numcommunities = 8
+    manyweights = rand(numspecies, numcommunities)
+    manyweights /= sum(manyweights)
 
-@testset "EcoBase interface" begin
+    species = map(n -> "Species $n", 1:numspecies)
+    communities = map(n -> "SC $n", 1:numcommunities)
+    #ut = UniqueTypes(species)
+    #sc = Subcommunities(communities)
+    mc = ComMatrix(manyweights, specnames = species, sitenames = communities)
+
+    @test all(EcoBase.thingnames(mc) .== species)
+    @test all(EcoBase.placenames(mc) .== communities)
+    @test all(EcoBase.occurrences(mc) .≈ manyweights)
+    @test all(EcoBase.richness(mc) .== repeat([numspecies], inner=numcommunities))
+    @test all(EcoBase.occupancy(mc) .== repeat([numcommunities], inner=numspecies))
+    fewerweights = deepcopy(manyweights)
+    fewerweights[1, 1] = 0
+    fewerweights /= sum(fewerweights)
+    fmc = ComMatrix(fewerweights, specnames = species, sitenames = communities)
+
+    @test EcoBase.noccupied(fmc) == numcommunities
+    @test EcoBase.noccurring(fmc) == numspecies
+    @test EcoBase.noccupied(fmc, 1) == numcommunities - 1
+    @test EcoBase.noccurring(fmc, 1) == numspecies - 1
+    @test EcoBase.nthings(fmc) == numspecies
+    @test EcoBase.nplaces(fmc) == numcommunities
+end
+
+@testset "EcoBase-Diversity interface" begin
+    numspecies = 10
+    numcommunities = 8
+    manyweights = rand(numspecies, numcommunities)
+    manyweights /= sum(manyweights)
+
     species = map(n -> "Species $n", 1:numspecies)
     communities = map(n -> "SC $n", 1:numcommunities)
     ut = UniqueTypes(species)


### PR DESCRIPTION
Necessary for the SpatialEcology interface. 
OK, I've been through the process of letting SpatialEcology use EcoBase. I'll explain what I've done here and there.

1. I've unexported everything. So names can be extended and exported downstream, or aliased, e.g. I have `const nspecies = nthings` defined in SpatialEcology.
2. I've let many more functions have a definition on AbstractAssemblage that simply defers to `occurrences(asm)`, given that they can be calculated on a simple Matrix.
3. I've cleaned up the PlotRecipes, some were reaching into the objects.
4. I've added the same tests for Interface, but for SpatialEcology. Note that since you have zero spatial information in your tests, this now tests `ComMatrix` rather than `Assemblage`. I should allow initializing `Assemblage` without spatial information I guess.
5. I've changed AbstractGrid to not be a subtype of `AbstractLocations`. That's because `Locations` also have site information, but I think of the `Grid` types as purely spatial (eventually I think we should coordinate with JuliaGeo), so now instead I have `Locations{<:AbstractGrid}`.