### PR TITLE
Add a legend, but no label associated with it for AbstractPlaces

### DIFF
--- a/src/DataTypes.jl
+++ b/src/DataTypes.jl
@@ -37,9 +37,9 @@ quadrats (see AbstractGrid).
 abstract type AbstractLocations <: AbstractPlaces end
 
 """
-    AbstractGrid <: AbstractLocations <: AbstractPlaces
+    AbstractGrid
 
-Subtype of AbstractLocations that refers to a grid of regularly
+Composed within AbstractLocations and refers to a grid of regularly
 spaced, identically shaped, locations.
 """
 abstract type AbstractGrid end

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -112,7 +112,7 @@ xrange(grd) = xmin(grd):xcellsize(grd):xmax(grd) #includes intermediary points
 yrange(grd) = ymin(grd):ycellsize(grd):ymax(grd)
 xmax(grd) = xmin(grd) + xcellsize(grd) * (xcells(grd) - 1)
 ymax(grd) = ymin(grd) + ycellsize(grd) * (ycells(grd) - 1)
-coordinates(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
 
 indices(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
 indices(grd::AbstractGrid, idx) = error("function not defined for $(typeof(grd))")
+coordinates(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -95,6 +95,9 @@ thingnames(asm::AbstractAssemblage, args...) = thingnames(things(asm), args...)
 # TODO:
 # accessing cache
 
+# Methods for AbstractPlaces
+coordinates(grd::AbstractPlaces) = error("function not defined for $(typeof(grd))")
+
 # Methods for AbstractGrid
 xmin(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
 ymin(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
@@ -111,4 +114,3 @@ ymax(grd) = ymin(grd) + ycellsize(grd) * (ycells(grd) - 1)
 
 indices(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
 indices(grd::AbstractGrid, idx) = error("function not defined for $(typeof(grd))")
-coordinates(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -10,7 +10,6 @@ nplaces(plc::AbstractPlaces)::Integer = error("function not defined for $(typeof
 nplaces(plc::AbstractAssemblage) = nplaces(places(plc))
 placenames(plc::AbstractPlaces)::AbstractVector{<:String} = error("function not defined for $(typeof(plc))")
 placenames(plc::AbstractAssemblage) = placenames(places(plc))
-getcoords(plc::AbstractPlaces) = error("function not defined for $(typeof(plc))") # to get either Grid or other location data out of a Places object
 
 nthings(thg::AbstractThings)::Integer = error("function not defined for $(typeof(thg))")
 nthings(asm::AbstractAssemblage) = nthings(things(asm))
@@ -96,7 +95,9 @@ thingnames(asm::AbstractAssemblage, args...) = thingnames(things(asm), args...)
 # accessing cache
 
 # Methods for AbstractPlaces
-coordinates(grd::AbstractPlaces) = error("function not defined for $(typeof(grd))")
+getcoords(plc::AbstractPlaces) = plc # Pure places generate their own fake location data
+getcoords(plc::AbstractLocations) = error("function not defined for $(typeof(plc))") # to get either Grid or other location data out of a AbstractLocations object
+coordinates(plc::AbstractPlaces) = error("function not defined for $(typeof(plc))")
 
 # Methods for AbstractGrid
 xmin(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
@@ -111,6 +112,7 @@ xrange(grd) = xmin(grd):xcellsize(grd):xmax(grd) #includes intermediary points
 yrange(grd) = ymin(grd):ycellsize(grd):ymax(grd)
 xmax(grd) = xmin(grd) + xcellsize(grd) * (xcells(grd) - 1)
 ymax(grd) = ymin(grd) + ycellsize(grd) * (ycells(grd) - 1)
+coordinates(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
 
 indices(grd::AbstractGrid) = error("function not defined for $(typeof(grd))")
 indices(grd::AbstractGrid, idx) = error("function not defined for $(typeof(grd))")

--- a/src/PlotRecipes.jl
+++ b/src/PlotRecipes.jl
@@ -24,17 +24,8 @@ RecipesBase.@recipe function f(var::AbstractVector, pnt::AbstractPlaces)
     aspect_ratio --> :equal
     grid --> false
     marker_z := var
-    label --> ""
-    cd = coordinates(pnt)
-    cd[:,1], cd[:,2]
-end
-
-RecipesBase.@recipe function f(var::AbstractVector, pnt::AbstractLocations)
-    seriestype := :scatter
-    aspect_ratio --> :equal
-    grid --> false
-    marker_z := var
     legend --> false
+    colorbar --> true
     cd = coordinates(pnt)
     cd[:,1], cd[:,2]
 end

--- a/src/PlotRecipes.jl
+++ b/src/PlotRecipes.jl
@@ -19,12 +19,22 @@ end
 #     ones(nsites(sit)), sit
 # end
 
-RecipesBase.@recipe function f(var::AbstractVector, pnt::AbstractLocations)
+RecipesBase.@recipe function f(var::AbstractVector, pnt::AbstractPlaces)
     seriestype := :scatter
     aspect_ratio --> :equal
     grid --> false
     marker_z := var
     label --> ""
+    cd = coordinates(pnt)
+    cd[:,1], cd[:,2]
+end
+
+RecipesBase.@recipe function f(var::AbstractVector, pnt::AbstractLocations)
+    seriestype := :scatter
+    aspect_ratio --> :equal
+    grid --> false
+    marker_z := var
+    legend --> false
     cd = coordinates(pnt)
     cd[:,1], cd[:,2]
 end

--- a/src/PlotRecipes.jl
+++ b/src/PlotRecipes.jl
@@ -24,7 +24,7 @@ RecipesBase.@recipe function f(var::AbstractVector, pnt::AbstractLocations)
     aspect_ratio --> :equal
     grid --> false
     marker_z := var
-    legend --> false
+    label --> ""
     cd = coordinates(pnt)
     cd[:,1], cd[:,2]
 end


### PR DESCRIPTION
@mkborregaard I'm not sure why you have the legend switched off for AbstractLocations? In case it was important, I've added in a new plot recipe for AbstractPlaces, which is the same, but with just a blank label so I can still see the scale that is being plotted.