### PR TITLE
make assemblage printing customizable

### DIFF
--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -12,8 +12,13 @@ occurrences(asm::AbstractAssemblage)::AbstractMatrix = error("function not defin
 view(asm::AbstractAssemblage) = error("function not defined for $(typeof(asm))")
 places(asm::AbstractAssemblage)::AbstractPlaces = error("function not defined for $(typeof(asm))")
 things(asm::AbstractAssemblage)::AbstractThings = error("function not defined for $(typeof(asm))")
+
+# for custom printing
 thingkind(asm::AbstractAssemblage) = "thing"
 placekind(asm::AbstractAssemblage) = "place"
+thingkindplural(asm::AbstractAssemblage) = "$(thingkind(asm))s"
+placekindplural(asm::AbstractAssemblage) = "$(placekind(asm))s"
+
 
 nplaces(plc::AbstractPlaces)::Integer = error("function not defined for $(typeof(plc))")
 nplaces(plc::AbstractAssemblage) = nplaces(places(plc))
@@ -78,9 +83,11 @@ function show(io::IO, asm::T) where T <: AbstractAssemblage
     tn = createsummaryline(thingnames(asm))
     pn = createsummaryline(placenames(asm))
     thing = titlecase(thingkind(asm))
+    things = thingkindplural(asm)
     place = titlecase(placekind(asm))
+    places = placekindplural(asm)
     println(io,
-    """$T with $(nthings(asm)) $(thing)s in $(nplaces(asm)) $(place)s
+    """$T with $(nthings(asm)) $things in $(nplaces(asm)) $places
 
     $thing names:
     $(tn)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -80,7 +80,7 @@ function show(io::IO, asm::T) where T <: AbstractAssemblage
     thing = titlecase(thingkind(asm))
     place = titlecase(placekind(asm))
     println(io,
-    """$T with $(nthings(asm)) things in $(nplaces(asm)) places
+    """$T with $(nthings(asm)) $(thing)s in $(nplaces(asm)) $(place)s
 
     $thing names:
     $(tn)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -12,6 +12,8 @@ occurrences(asm::AbstractAssemblage)::AbstractMatrix = error("function not defin
 view(asm::AbstractAssemblage) = error("function not defined for $(typeof(asm))")
 places(asm::AbstractAssemblage)::AbstractPlaces = error("function not defined for $(typeof(asm))")
 things(asm::AbstractAssemblage)::AbstractThings = error("function not defined for $(typeof(asm))")
+thingkind(asm::AbstractAssemblage) = "thing"
+placekind(asm::AbstractAssemblage) = "place"
 
 nplaces(plc::AbstractPlaces)::Integer = error("function not defined for $(typeof(plc))")
 nplaces(plc::AbstractAssemblage) = nplaces(places(plc))
@@ -75,13 +77,15 @@ end
 function show(io::IO, asm::T) where T <: AbstractAssemblage
     tn = createsummaryline(thingnames(asm))
     pn = createsummaryline(placenames(asm))
+    thing = titlecase(thingkind(asm))
+    place = titlecase(placekind(asm))
     println(io,
     """$T with $(nthings(asm)) things in $(nplaces(asm)) places
 
-    Thing names:
+    $thing names:
     $(tn)
 
-    Place names:
+    $place names:
     $(pn)
     """)
 end


### PR DESCRIPTION
Minor change that enables customization of `show` for `AbstractAssemblage`s just by defining `thingkind` and `placekind` functions. So for example, a `ComMatrix` could define `thingkind(cm::ComMatrix) = "species"` and `placekind(cm::ComMatrix) = "site"`, and get 

```
# ...
Species names:
# ...

Site names:
# ...
```

instead of [redefining here](https://github.com/EcoJulia/SpatialEcology.jl/blob/f21cc7e5635ab31d30d390d61c65c2ff4f4633bf/src/ComMatrix.jl#L77-L81)

One complication is that the plural parts (eg) `5 things in 10 places` or whatever here are just naively putting an `s` at the end of whatever the `(thing|place)kind` is, so `species` will end up being `5 speciess`. We could also define `thingplural(thing) = "$(thingkind(thing))s" so that can be overridden. Or we could just leave "things" and "places" in the summary line alone, rather than filling them in.